### PR TITLE
iOS bitrate reporting fix

### DIFF
--- a/ios/RCTVideo.xcodeproj/project.pbxproj
+++ b/ios/RCTVideo.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		39D0DC3E29CE4D3D00FC784F /* RCTPlaybackBitrateEmitter.m in Sources */ = {isa = PBXBuildFile; fileRef = 39D0DC3C29CE4D3D00FC784F /* RCTPlaybackBitrateEmitter.m */; };
+		39D0DC3F29CE4D3D00FC784F /* RCTPlaybackBitrateEmitter.m in Sources */ = {isa = PBXBuildFile; fileRef = 39D0DC3C29CE4D3D00FC784F /* RCTPlaybackBitrateEmitter.m */; };
 		D1107C0A2110259000073188 /* UIView+FindUIViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D1107C032110259000073188 /* UIView+FindUIViewController.m */; };
 		D1107C0B2110259000073188 /* UIView+FindUIViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D1107C032110259000073188 /* UIView+FindUIViewController.m */; };
 		D1107C0C2110259000073188 /* RCTVideo.m in Sources */ = {isa = PBXBuildFile; fileRef = D1107C052110259000073188 /* RCTVideo.m */; };
@@ -40,6 +42,8 @@
 
 /* Begin PBXFileReference section */
 		134814201AA4EA6300B7C361 /* libRCTVideo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRCTVideo.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		39D0DC3C29CE4D3D00FC784F /* RCTPlaybackBitrateEmitter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RCTPlaybackBitrateEmitter.m; path = Video/RCTPlaybackBitrateEmitter.m; sourceTree = "<group>"; };
+		39D0DC3D29CE4D3D00FC784F /* RCTPlaybackBitrateEmitter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RCTPlaybackBitrateEmitter.h; path = Video/RCTPlaybackBitrateEmitter.h; sourceTree = "<group>"; };
 		641E28441F0EEC8500443AF6 /* libRCTVideo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRCTVideo.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		D1107C012110259000073188 /* RCTVideoPlayerViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RCTVideoPlayerViewController.h; path = Video/RCTVideoPlayerViewController.h; sourceTree = "<group>"; };
 		D1107C022110259000073188 /* RCTVideoPlayerViewControllerDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RCTVideoPlayerViewControllerDelegate.h; path = Video/RCTVideoPlayerViewControllerDelegate.h; sourceTree = "<group>"; };
@@ -97,6 +101,8 @@
 				D1107C022110259000073188 /* RCTVideoPlayerViewControllerDelegate.h */,
 				D1107C042110259000073188 /* UIView+FindUIViewController.h */,
 				D1107C032110259000073188 /* UIView+FindUIViewController.m */,
+				39D0DC3D29CE4D3D00FC784F /* RCTPlaybackBitrateEmitter.h */,
+				39D0DC3C29CE4D3D00FC784F /* RCTPlaybackBitrateEmitter.m */,
 				134814211AA4EA7D00B7C361 /* Products */,
 				641E28441F0EEC8500443AF6 /* libRCTVideo.a */,
 				49E995712048B4CE00EA7890 /* Frameworks */,
@@ -182,6 +188,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				39D0DC3E29CE4D3D00FC784F /* RCTPlaybackBitrateEmitter.m in Sources */,
 				D1107C0A2110259000073188 /* UIView+FindUIViewController.m in Sources */,
 				D1107C102110259000073188 /* RCTVideoPlayerViewController.m in Sources */,
 				D1107C0E2110259000073188 /* RCTVideoManager.m in Sources */,
@@ -193,6 +200,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				39D0DC3F29CE4D3D00FC784F /* RCTPlaybackBitrateEmitter.m in Sources */,
 				D1107C0B2110259000073188 /* UIView+FindUIViewController.m in Sources */,
 				D1107C112110259000073188 /* RCTVideoPlayerViewController.m in Sources */,
 				D1107C0F2110259000073188 /* RCTVideoManager.m in Sources */,

--- a/ios/Video/RCTPlaybackBitrateEmitter.h
+++ b/ios/Video/RCTPlaybackBitrateEmitter.h
@@ -1,0 +1,16 @@
+//
+//  playbackBitrateEmitter.h
+//  labs2020mobile
+//
+//  Created by Farales, Ron on 11/4/22.
+//
+
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
+
+@interface playbackBitrateEmitter : RCTEventEmitter <RCTBridgeModule>
+
+//@property (nonatomic, strong) playbackBitrateEmitter *sharedEmitter;
++ (void)emitBitrateEvent:(double)bitrate;
+
+@end

--- a/ios/Video/RCTPlaybackBitrateEmitter.m
+++ b/ios/Video/RCTPlaybackBitrateEmitter.m
@@ -1,0 +1,56 @@
+//
+//  playbackBitrateEmitter.m
+//  labs2020mobile
+//
+//  Created by Farales, Ron on 11/4/22.
+//
+
+#import <Foundation/Foundation.h>
+#import "RCTPlaybackBitrateEmitter.h"
+#import <React/RCTLog.h>
+#import <React/RCTUIManager.h>
+
+@implementation playbackBitrateEmitter
+
+  RCT_EXPORT_MODULE();
+
+  bool hasBitrateListeners;
+  playbackBitrateEmitter *sharedEmitter;
+
+  -(instancetype)init
+  {
+    self = [super init];
+    
+    sharedEmitter = self;
+    
+    return self;
+  }
+
+  - (NSArray<NSString *> *)supportedEvents {
+    return @[@"BITRATE_UPDATE"];
+  }
+  
+  - (void)startObserving {
+    hasBitrateListeners = YES;
+  }
+  
+  - (void)stopObserving {
+    hasBitrateListeners = NO;
+  }
+  
+
+  + (void)emitBitrateEvent:(double)bitrate {
+    if (hasBitrateListeners) {
+      NSString* bitrateString = [@(bitrate) stringValue];
+      [sharedEmitter sendEventWithName:@"BITRATE_UPDATE" body:@{@"bitrate": bitrateString}];
+    }
+  }
+
+  
+  + (BOOL)requiresMainQueueSetup {
+    return NO;
+  }
+  
+@end
+
+

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -5,7 +5,7 @@
 #import <React/UIView+React.h>
 #include <MediaAccessibility/MediaAccessibility.h>
 #include <AVFoundation/AVFoundation.h>
-#import "PlaybackBitrateEmitter.h"
+#import "RCTPlaybackBitrateEmitter.h"
 
 static NSString *const statusKeyPath = @"status";
 static NSString *const playbackLikelyToKeepUpKeyPath = @"playbackLikelyToKeepUp";

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -5,6 +5,7 @@
 #import <React/UIView+React.h>
 #include <MediaAccessibility/MediaAccessibility.h>
 #include <AVFoundation/AVFoundation.h>
+#import "PlaybackBitrateEmitter.h"
 
 static NSString *const statusKeyPath = @"status";
 static NSString *const playbackLikelyToKeepUpKeyPath = @"playbackLikelyToKeepUp";
@@ -206,8 +207,7 @@ static int const RCTVideoUnset = -1;
         
     if (isinf(bitrate) || isnan(bitrate) || (bitrate <= 1)){return;}
         
-    if (self.onVideoStreamBandwidthUpdate)
-        self.onVideoStreamBandwidthUpdate(@{@"bitrate": [NSNumber numberWithDouble:bitrate]});
+    [playbackBitrateEmitter emitBitrateEvent:bitrate];
 
 }
 

--- a/ios/Video/playbackBitrateEmitter.ts
+++ b/ios/Video/playbackBitrateEmitter.ts
@@ -1,0 +1,19 @@
+/*
+ *  This program is protected under international and U.S. copyright laws as
+ *  an unpublished work. This program is confidential and proprietary to the
+ *  copyright owners. Reproduction or disclosure, in whole or in part, or the
+ *  production of derivative works therefrom without the express permission of
+ *  the copyright owners is prohibited.
+ *
+ *                  Copyright © 2022 by Dolby Laboratories.
+ *                          All rights reserved.
+ *
+ */
+
+import {NativeModules} from 'react-native';
+const {playbackBitrateEmitter} = NativeModules;
+
+export interface playbackBitrateEmitterInterface {
+}
+
+export default playbackBitrateEmitter as playbackBitrateEmitterInterface;


### PR DESCRIPTION
This update fixes unreliable bitrate reporting of traditional playbacks due to the callback function in the React Native Video module not being instantiated and ready to receive bitrates when they arrive.  This approach bypasses the build-in messaging of React Native Video and adds a native event emitter class to React Native Video's Objective-C code to directly send bitrates to a listener in the Javascript code.