### PR TITLE
Reverted to older commit that uses React Native's built-in messenging…

### DIFF
--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -146,6 +146,11 @@ static int const RCTVideoUnset = -1;
                                              selector:@selector(audioRouteChanged:)
                                                  name:AVAudioSessionRouteChangeNotification
                                                object:nil];
+      
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(bandwidthUpdated:)
+                                                 name:AVPlayerItemNewAccessLogEntryNotification
+                                               object:nil];
   }
   
   return self;
@@ -820,13 +825,6 @@ static int const RCTVideoUnset = -1;
                                                name:AVPlayerItemPlaybackStalledNotification
                                              object:nil];
   
-  [[NSNotificationCenter defaultCenter] removeObserver:self
-                                                  name:AVPlayerItemNewAccessLogEntryNotification
-                                                object:nil];
-  [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:@selector(bandwidthUpdated:)
-                                               name:AVPlayerItemNewAccessLogEntryNotification
-                                             object:nil];
   [[NSNotificationCenter defaultCenter] removeObserver:self
                                                   name: AVPlayerItemFailedToPlayToEndTimeNotification
                                                 object:nil];


### PR DESCRIPTION
… system (removed PlaybackBitrateListener class)

Fixed bitrate listener missing early bitrate reports by moving listener to initWithEventDispatcher method