### PR TITLE
Drop tvOS conditional for track selection

### DIFF
--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -1169,20 +1169,12 @@ static int const RCTVideoUnset = -1;
       }
     }
   } else { // default. invalid type or "system"
-    #if TARGET_OS_TV
-    // Do noting. Fix for tvOS native audio menu language selector
-    #else
-      [_player.currentItem selectMediaOptionAutomaticallyInMediaSelectionGroup:group];
-      return;
-    #endif
+    [_player.currentItem selectMediaOptionAutomaticallyInMediaSelectionGroup:group];
+    return;
   }
 
-    #if TARGET_OS_TV
-    // Do noting. Fix for tvOS native audio menu language selector
-    #else
-       // If a match isn't found, option will be nil and text tracks will be disabled
-       [_player.currentItem selectMediaOption:mediaOption inMediaSelectionGroup:group];
-    #endif
+  // If a match isn't found, option will be nil and text tracks will be disabled
+  [_player.currentItem selectMediaOption:mediaOption inMediaSelectionGroup:group];
 }
 
 - (void)setSelectedAudioTrack:(NSDictionary *)selectedAudioTrack {


### PR DESCRIPTION
#### Describe the changes
This removes the OS conditional statement that prevents setting text and audio tracks for HLS on tvOS